### PR TITLE
Update Disney Streaming Smithy to 0.0.26

### DIFF
--- a/disney-lock.nix
+++ b/disney-lock.nix
@@ -1,4 +1,4 @@
 {
-"version"="0.0.25";
-"outputHash"= "sha256-TPKVVkThm1CLs7PQz0SVg1xKIPc6/LHvynbM/jskE30=";
+"version"="0.0.26";
+"outputHash"= "sha256-R36EPMi7Z7TVqfonaosE9FDE9F81HS4Pr2DwDsyctgc=";
 }


### PR DESCRIPTION
Update Disney Streaming Smithy to version `0.0.26`. See https://github.com/disneystreaming/smithy-language-server