### PR TITLE
Update Disney Streaming Smithy to 0.0.27

### DIFF
--- a/disney-lock.nix
+++ b/disney-lock.nix
@@ -1,4 +1,4 @@
 {
-"version"="0.0.26";
-"outputHash"= "sha256-R36EPMi7Z7TVqfonaosE9FDE9F81HS4Pr2DwDsyctgc=";
+"version"="0.0.27";
+"outputHash"= "sha256-fcs6HXK+uxIVMbz5tsKBJ2vsn2EoS7VW63rw73NEMYY=";
 }


### PR DESCRIPTION
Update Disney Streaming Smithy to version `0.0.27`. See https://github.com/disneystreaming/smithy-language-server