### PR TITLE
Update Disney Streaming Smithy to 0.0.30

### DIFF
--- a/disney-lock.nix
+++ b/disney-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "0.0.28";
-  "outputHash" = "sha256-wcjrqvy4ELPeFKdLTVOKS1ks9qxpzcwR+j3uHxKG9Po=";
+  "version" = "0.0.30";
+  "outputHash" = "sha256-DubCa7CPSsFv924on/989/+/CcSrdWQRS3bgy2SXHno=";
 }


### PR DESCRIPTION
Update Disney Streaming Smithy to version `0.0.30`. See https://github.com/disneystreaming/smithy-language-server